### PR TITLE
Fix multiple attempts to create destination folder

### DIFF
--- a/tasks/css_purge.js
+++ b/tasks/css_purge.js
@@ -55,19 +55,18 @@ module.exports = function( Grunt ) {
 				return;
 			}
 
+			// Create destionation folder if we have to
+			if( !Fs.existsSync( Path.dirname( destFile ) ) ) {
+				const newFolder = Path.dirname( destFile );
+
+				Grunt.file.mkdir( newFolder, null );
+				Grunt.log.writeln( Chalk.cyan('"' + newFolder + '/" has been created' ) );
+			}
+
 			let CSS = '';
 
 			// Iterate over all files
 			srcFiles.forEach( ( srcFile ) => {
-
-				// Create folder if we have to
-				if( !Fs.existsSync( Path.dirname( destFile ) ) ) {
-					const newFolder = Path.dirname( destFile );
-
-					Grunt.file.mkdir( newFolder, null );
-					Grunt.log.writeln( Chalk.cyan('"' + newFolder + '/" has been created' ) );
-				}
-
 				// Get all CSS together
 				CSS += Grunt.file.read( srcFile );
 			});


### PR DESCRIPTION
I moved the creation of the destination folder outside of the `srcFiles.forEach` loop since that loop doesn't change any variables used by the mkdir functionality.

If grunt allows the `destFile` to be an array then the function would need to be modified to accept this option and could be created as a separate PR.